### PR TITLE
Add error handling UI across dashboard and budget pages

### DIFF
--- a/src/pages/ApprovalCenter.tsx
+++ b/src/pages/ApprovalCenter.tsx
@@ -15,7 +15,7 @@ import {
   Target,
   TrendingUp,
   Bell,
-  AlertCircle,
+  AlertTriangle,
   ChevronDown,
   ChevronUp,
   DollarSign,

--- a/src/pages/ApprovalCenter.tsx
+++ b/src/pages/ApprovalCenter.tsx
@@ -93,6 +93,7 @@ const ApprovalCenter: React.FC = () => {
     sendToSupplyChain,
     addComment
   } = useWorkflow();
+  const { error: workflowError } = useWorkflow();
   
   const [selectedFilter, setSelectedFilter] = useState<WorkflowState | 'all'>('submitted');
   const [selectedType, setSelectedType] = useState<'all' | 'sales_budget' | 'rolling_forecast'>('all');

--- a/src/pages/ApprovalCenter.tsx
+++ b/src/pages/ApprovalCenter.tsx
@@ -678,6 +678,21 @@ const ApprovalCenter: React.FC = () => {
   return (
     <Layout>
       <div className="space-y-6">
+        {/* Error Display */}
+        {workflowError && (
+          <div className="bg-red-50 border border-red-200 rounded-md p-4">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <AlertTriangle className="h-5 w-5 text-red-400" />
+              </div>
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-red-800">Workflow Data Error</h3>
+                <div className="mt-2 text-sm text-red-700">{workflowError}</div>
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Enhanced Header with Department Context */}
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
           <div className="flex items-center justify-between mb-6">

--- a/src/pages/ApprovalCenter.tsx
+++ b/src/pages/ApprovalCenter.tsx
@@ -91,9 +91,9 @@ const ApprovalCenter: React.FC = () => {
     approveItem,
     rejectItem,
     sendToSupplyChain,
-    addComment
+    addComment,
+    error: workflowError
   } = useWorkflow();
-  const { error: workflowError } = useWorkflow();
   
   const [selectedFilter, setSelectedFilter] = useState<WorkflowState | 'all'>('submitted');
   const [selectedType, setSelectedType] = useState<'all' | 'sales_budget' | 'rolling_forecast'>('all');

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -18,7 +18,7 @@ import { initializeCommunicationDemo } from '../utils/communicationDemo';
 const Dashboard: React.FC = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
-  const { stockRequests, stockAlerts, stockProjections, stockOverviews, getRequestsBySalesman } = useStock();
+  const { stockRequests, stockAlerts, stockProjections, stockOverviews, getRequestsBySalesman, error: stockError, isLoading: stockLoading } = useStock();
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
   const [notification, setNotification] = useState<{message: string, type: 'success' | 'error'} | null>(null);
   const [isGitEtaModalOpen, setIsGitEtaModalOpen] = useState(false);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import UserCommunicationCenter from '../components/UserCommunicationCenter';
 import CommunicationDemoInfo from '../components/CommunicationDemoInfo';
 import { useAuth, getUserRoleName } from '../contexts/AuthContext';
 import { useStock } from '../contexts/StockContext';
+import { useBudget } from '../contexts/BudgetContext';
 import { initializeCommunicationDemo } from '../utils/communicationDemo';
 
 
@@ -19,6 +20,7 @@ const Dashboard: React.FC = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const { stockRequests, stockAlerts, stockProjections, stockOverviews, getRequestsBySalesman, error: stockError, isLoading: stockLoading } = useStock();
+  const { error: budgetError, isLoading: budgetLoading } = useBudget();
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
   const [notification, setNotification] = useState<{message: string, type: 'success' | 'error'} | null>(null);
   const [isGitEtaModalOpen, setIsGitEtaModalOpen] = useState(false);
@@ -587,6 +589,24 @@ const Dashboard: React.FC = () => {
               : 'bg-red-600 text-white'
           }`}>
             {notification.message}
+          </div>
+        )}
+
+        {/* Error Display */}
+        {(stockError || budgetError) && (
+          <div className="bg-red-50 border border-red-200 rounded-md p-4 mx-4">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <AlertTriangle className="h-5 w-5 text-red-400" />
+              </div>
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-red-800">System Errors</h3>
+                <div className="mt-2 text-sm text-red-700">
+                  {stockError && <div>• {stockError}</div>}
+                  {budgetError && <div>• {budgetError}</div>}
+                </div>
+              </div>
+            </div>
           </div>
         )}
 

--- a/src/pages/RollingForecast.tsx
+++ b/src/pages/RollingForecast.tsx
@@ -30,7 +30,7 @@ import {
 
 const RollingForecast: React.FC = () => {
   const { user } = useAuth();
-  const { yearlyBudgets, getBudgetsByCustomer } = useBudget();
+  const { yearlyBudgets, getBudgetsByCustomer, error: budgetError } = useBudget();
   const { submitForApproval } = useWorkflow();
   const [selectedCustomer, setSelectedCustomer] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('');

--- a/src/pages/RollingForecast.tsx
+++ b/src/pages/RollingForecast.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Layout from '../components/Layout';
-import { ChevronRight, Eye, CheckCircle, Plus, ChevronUp, ChevronDown, Minus, X, List, UserPlus, Target, Send, Download as DownloadIcon, Package, Calendar } from 'lucide-react';
+import { ChevronRight, Eye, CheckCircle, Plus, ChevronUp, ChevronDown, Minus, X, List, UserPlus, Target, Send, Download as DownloadIcon, Package, Calendar, AlertTriangle } from 'lucide-react';
 import { Customer } from '../types/forecast';
 import { useBudget } from '../contexts/BudgetContext';
 import { useAuth } from '../contexts/AuthContext';

--- a/src/pages/RollingForecast.tsx
+++ b/src/pages/RollingForecast.tsx
@@ -854,6 +854,21 @@ const RollingForecast: React.FC = () => {
           <span className="text-blue-600 font-medium">Rolling Forecast</span>
         </div>
 
+        {/* Error Display */}
+        {budgetError && (
+          <div className="bg-red-50 border border-red-200 rounded-md p-4">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <AlertTriangle className="h-5 w-5 text-red-400" />
+              </div>
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-red-800">Budget Data Error</h3>
+                <div className="mt-2 text-sm text-red-700">{budgetError}</div>
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Header */}
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold text-gray-900">Rolling Forecast for 2025-2026</h1>

--- a/src/pages/SalesBudget.tsx
+++ b/src/pages/SalesBudget.tsx
@@ -15,7 +15,8 @@ import {
   Calendar,
   Send,
   Package,
-  Users
+  Users,
+  AlertTriangle
 } from 'lucide-react';
 import ExportModal, { ExportConfig } from '../components/ExportModal';
 import NewAdditionModal, { NewItemData } from '../components/NewAdditionModal';

--- a/src/pages/SalesBudget.tsx
+++ b/src/pages/SalesBudget.tsx
@@ -1021,6 +1021,20 @@ const SalesBudget: React.FC = () => {
   return (
     <Layout>
       <div className="min-h-screen bg-gray-100 font-sans">
+        {/* Error Display */}
+        {budgetError && (
+          <div className="bg-red-50 border border-red-200 rounded-md p-4 m-4">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <AlertTriangle className="h-5 w-5 text-red-400" />
+              </div>
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-red-800">Budget Data Error</h3>
+                <div className="mt-2 text-sm text-red-700">{budgetError}</div>
+              </div>
+            </div>
+          </div>
+        )}
         {/* Main Content Container */}
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 m-4 overflow-hidden">
           {/* Stats Cards Row */}

--- a/src/pages/SalesBudget.tsx
+++ b/src/pages/SalesBudget.tsx
@@ -67,7 +67,7 @@ interface SalesBudgetItem {
 
 const SalesBudget: React.FC = () => {
   const { user } = useAuth();
-  const { addYearlyBudget, yearlyBudgets } = useBudget();
+  const { addYearlyBudget, yearlyBudgets, error: budgetError } = useBudget();
   const { submitForApproval, getNotificationsForUser } = useWorkflow();
   const [selectedCustomer, setSelectedCustomer] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('');


### PR DESCRIPTION
<h3>Update from the Builder.io Visual Editor.</h3>
<p>The builder.io bot is busy generating a detailed description...</p>
<p align='left'><img src='https://cdn.builder.io/api/v1/file/assets%2FYJIGb4i01jvw0SRdL5Bt%2F848ca4d0600646539f0d46e1e6b1f0d3' width='32' height='32'></p>
<p>tag @builderio-bot for anything you want the bot to do</p>
<p>To clone this PR locally use the <a href="https://cli.github.com/">GitHub CLI</a> with command <code>gh pr checkout 3</code></p>
<!--<projectId>8e6995c089f04a50972143a414774018</projectId>-->
<!--<branchName>vortex-den</branchName>-->

## Summary by Sourcery

Add error alert UI to key pages to surface context errors

Enhancements:
- Include error state from stock, budget, and workflow contexts in relevant pages
- Render styled error alert panels with AlertTriangle icon on Dashboard, ApprovalCenter, RollingForecast, and SalesBudget
- Replace AlertCircle with AlertTriangle icon in ApprovalCenter